### PR TITLE
Render document placeholder

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -292,7 +292,6 @@ module.exports = function (grunt) {
         watch: {
             js: {
                 files: ['<%= paths.app %>/**/*.js'],
-                tasks: ['jshint'],
                 options: {
                     livereload: true
                 }

--- a/app/viewmodels/document.js
+++ b/app/viewmodels/document.js
@@ -1,0 +1,13 @@
+define(['plugins/http', 'durandal/app', 'knockout'], function (http, app, ko) {
+
+    var sha1 = ko.observable();
+    var path = ko.observable();
+    return {
+        sha1: sha1,
+        path: path,
+        activate: function(routeSha1, routePath) {
+            sha1(routeSha1);
+            path(routePath);
+        }
+    };
+});

--- a/app/viewmodels/repository.js
+++ b/app/viewmodels/repository.js
@@ -18,7 +18,7 @@
       var current = root;
 
       segments.forEach(function(segment){
-        current.nodes[segment] = current.nodes[segment] || new Node(segment);
+        current.nodes[segment] = current.nodes[segment] || new Node(segment, current);
         current = current.nodes[segment];
       });
 
@@ -28,14 +28,15 @@
     return root;
   }
 
-  function Node(name){
+  function Node(name, parent){
     this.nodes = {};
     this.source = null;
     this.name = name;
+    this.parent = parent;
   }
 
   Node.prototype.isFolder = function(){
-    return this.source.type === 'folder';
+    return this.source.type === 'tree';
   };
 
   Node.prototype.nodesToArray = function(){
@@ -52,6 +53,13 @@
     // why does this not render in the order I'm expecting?
     return folders.concat(files);
   };
+
+    Node.prototype.fullPath = function() {
+        if (!this.parent) {
+            return '';
+        }
+        return this.parent.fullPath() + '/' + this.name;
+    };
 
     return {
         displayName: 'Comment',
@@ -76,8 +84,8 @@
           });
         },
 
-        select: function(item) {
-          debugger;
+        linkFromPath: function(path) {
+            return '#document/' + this.sha() + path;
         }
     };
 });

--- a/app/viewmodels/shell.js
+++ b/app/viewmodels/shell.js
@@ -9,7 +9,8 @@
         activate: function () {
             router.map([
                 { route: '', title:'Welcome', moduleId: 'viewmodels/welcome', nav: true },
-              { route: ':owner/:repo', moduleId: 'viewmodels/repository' }
+                { route: ':owner/:repo', moduleId: 'viewmodels/repository' },
+                { route: 'document/:sha1/*path', moduleId: 'viewmodels/document' }
             ]).buildNavigationModel();
 
             return router.activate();

--- a/app/views/document.html
+++ b/app/views/document.html
@@ -1,0 +1,4 @@
+<div>
+  If this were done, you'd be looking at <code data-bind="text: path"></code>
+  at revision <code data-bind="text: sha1"></code>.
+</div>

--- a/app/views/repository.html
+++ b/app/views/repository.html
@@ -4,11 +4,13 @@
 
   <script id="itemTmpl" type="text/html">
     <li>
-      <a href="#" data-bind="click:$parent.select">
+      <!-- ko if: !isFolder() -->
+      <a data-bind="attr: { href: $root.linkFromPath($data.fullPath($data)) }">
         <span data-bind="text: name"></span>
       </a>
-
-      <!-- ko if: isFolder -->
+      <!-- /ko -->
+      <!-- ko if: isFolder() -->
+      <span data-bind="text: name"></span>
       <ul data-bind="template: { name: 'itemTmpl', foreach: nodesToArray() }"></ul>
       <!-- /ko -->
     </li>


### PR DESCRIPTION
Treeview of a repository shows links only on leaf nodes. Links load a placeholder page with route knowledge of SHA1 of commit and full file path inside repository. May or may not contain questionable whitespace formatting decisions.