### PR TITLE
Fetch raw blobs with tree path in url.

### DIFF
--- a/app/modules/github.js
+++ b/app/modules/github.js
@@ -8,37 +8,45 @@ define(['knockout', 'durandal/system', 'plugins/http', './node'], function(ko, s
       'Accept' : 'application/vnd.github.v3+json'
       };
 
-    function Github() {}
+    function Github() {
+        this.repositories = {};
+    }
 
-    Github.prototype.fetchRepository = function(owner, repo) {
-
+    Github.prototype.fetchRepository = function(owner, repo, sha1) {
+      var self = this;
       // todo: the desired sha should be provided by
       // the owner requesting the feedback
 
-        var sha1 = 'master';
+      // todo: check self.repositories to see if the requested sha1
+      // has already been loaded. If so, wrap in a promise and go.
+
+        sha1 = sha1 || 'master';
         var url = base_url + 'repos/' + owner + '/' + repo + '/git/trees/' + sha1 + '?recursive=1';
 
         return http.get(url, null, base_headers).then(function(response, status, xhr) {
             if (response.truncated) { /* signal error condition */ }
             var root = Node.unflatten(response.tree);
             root.sha = response.sha;
+            root.shortSha = response.sha.substring(0,7);
+            self.repositories[root.sha] = root;
+            self.repositories[root.shortSha] = root;
             return root;
         });
     };
 
-    Github.prototype.fetchRawFile = function(owner, repo, sha1) {
+    Github.prototype.fetchRawFile = function(owner, repo, commitSha1, filePath) {
+        return this.fetchRepository(owner, repo, commitSha1).then(function(repository) {
+            var file = repository.lookupFileByPath(filePath);
+            var url = base_url + 'repos/' + owner + '/' + repo + '/git/blobs/' + file.blobSha();
 
-      var url = base_url + 'repos/' + owner + '/' + repo + '/git/blobs/' + sha1;
-
-      var headers = {
-        'Accept' : 'application/vnd.github.v3+json'
-      };
-
-      return http.get(url, null, base_headers).then(function(response, status, xhr) {
-        var decoded = atob(response.content);
-        return decoded;
-      });
+            return http.get(url, null, base_headers).then(function(response, status, xhr) {
+                var decoded = atob(response.content);
+                return decoded;
+            });
+        });
     };
+
+    Github.instance = new Github();
 
     return Github;
 });

--- a/app/modules/github.js
+++ b/app/modules/github.js
@@ -17,8 +17,9 @@ define(['knockout', 'durandal/system', 'plugins/http', './node'], function(ko, s
       // todo: the desired sha should be provided by
       // the owner requesting the feedback
 
-      // todo: check self.repositories to see if the requested sha1
-      // has already been loaded. If so, wrap in a promise and go.
+        if (sha1 && sha1 !== '' && self.repositories[sha1]) {
+            return system.defer(function(cb) { cb.resolve(self.repositories[sha1]); });
+        }
 
         sha1 = sha1 || 'master';
         var url = base_url + 'repos/' + owner + '/' + repo + '/git/trees/' + sha1 + '?recursive=1';

--- a/app/modules/node.js
+++ b/app/modules/node.js
@@ -60,7 +60,31 @@ define(['knockout', 'durandal/system', 'plugins/http'], function(ko, system, htt
     };
 
     Node.prototype.fullPath = function() {
-        return '/' + this.source.path;
+        return this.source.path;
+    };
+
+    // might make more sense to keep the original response in memory,
+    // rather than recurse back through the tree we built.
+    Node.prototype.lookupFileByPath = function(path) {
+        if (!path || path.length === 0) { return null; }
+        var i;
+        var segments = path.split('/', 1);
+        var restOfPath = path.substring(segments[0].length + 1);
+        var childNode = this.nodes[segments[0]];
+        if (!childNode) {
+            return null;
+        } else if (childNode.isFolder()) {
+            return childNode.lookupFileByPath(restOfPath);
+        } else {
+            return childNode;
+        }
+    };
+
+    Node.prototype.blobSha = function() {
+        if (this.isFolder()) {
+            throw "Called blobSha on a folder";
+        }
+        return this.source.sha;
     };
 
     return Node;

--- a/app/viewmodels/document.js
+++ b/app/viewmodels/document.js
@@ -1,6 +1,6 @@
 define(['plugins/http', 'durandal/app', 'knockout', '../modules/github'], function (http, app, ko, Github) {
 
-    var github = new Github();
+    var github = Github.instance;
     var sha1 = ko.observable();
     var path = ko.observable();
 
@@ -10,11 +10,11 @@ define(['plugins/http', 'durandal/app', 'knockout', '../modules/github'], functi
         content: ko.observable('loading...'),
         activate: function(routeOwner, routeRepo, routeSha1, routePath) {
             var self = this;
-            
+
             sha1(routeSha1);
             path(routePath);
 
-            github.fetchRawFile(routeOwner, routeRepo, routeSha1).then(function(content){
+            github.fetchRawFile(routeOwner, routeRepo, routeSha1, routePath).then(function(content){
               self.content(content);
             });
         }

--- a/app/viewmodels/repository.js
+++ b/app/viewmodels/repository.js
@@ -1,11 +1,18 @@
-'use strict';
+﻿'use strict';
 define(['plugins/http', 'durandal/app', 'knockout', '../modules/github'], function (http, app, ko, Github) {
-    var github = new Github();
+    var github = Github.instance;
+
+    // defining these in the function scope as linkToDocument is not
+    // called in the right context, and this is cleaner than a bind in
+    // the template
+    var repositoryOwner =  ko.observable('');
+    var repositoryName = ko.observable('');
+    var commitSha = ko.observable('');
 
     return {
-        owner: ko.observable(''),
-        repo: ko.observable(''),
-        sha: ko.observable(''),
+        owner: repositoryOwner,
+        repo: repositoryName,
+        sha: commitSha,
         tree: ko.observable({}),
 
         activate: function (owner, repo) {
@@ -15,13 +22,17 @@ define(['plugins/http', 'durandal/app', 'knockout', '../modules/github'], functi
           self.repo(repo);
 
           return github.fetchRepository(owner, repo).then(function(rootNode) {
-              self.sha(rootNode.sha);
+              self.sha(rootNode.shortSha);
               self.tree(rootNode);
           });
         },
 
-        linkFromPath: function(path) {
-            return '#document/' + owner + '/' + repo + '/' + this.sha() + path;
+        linkToDocument: function(document) {
+            return '#document/' +
+                repositoryOwner() + '/' +
+                repositoryName() + '/' +
+                commitSha() + '/' +
+                document.fullPath();
         }
     };
 });

--- a/app/viewmodels/shell.js
+++ b/app/viewmodels/shell.js
@@ -10,7 +10,7 @@
             router.map([
                 { route: '', title:'Welcome', moduleId: 'viewmodels/welcome', nav: true },
                 { route: ':owner/:repo', moduleId: 'viewmodels/repository' },
-                { route: 'document/:owner/:repo/:sha1', moduleId: 'viewmodels/document' }
+                { route: 'document/:owner/:repo/:sha1/*path', moduleId: 'viewmodels/document' }
             ]).buildNavigationModel();
 
             return router.activate();

--- a/app/views/repository.html
+++ b/app/views/repository.html
@@ -6,7 +6,7 @@
     <li>
       <!-- ko if: !isFolder() -->
       <i class="fa fa-file-o"></i>
-      <a data-bind="attr: { href: '#document/' + $root.owner() + '/' + $root.repo() + '/' + source.sha }">
+      <a data-bind="attr: { href: $root.linkToDocument($data) }">
         <span data-bind="text: name"></span>
       </a>
       <!-- /ko -->


### PR DESCRIPTION
This change allows URLs like http://localhost:9000/#document/mspnp/data-pipeline/57814b7/docs/GettingStarted/Console.md to work.

This request obviously requires loading commit `57814b7` and parsing out the blob ref for `Console.md`. This implementation naively makes 2 requests (1 for the tree, 1 for the raw data), unless the tree is already in memory, in which case it only requests the raw data. In cases where visitors are navigating from a tree-view, this will result in no additional requests.