### PR TITLE
Launch gulp-express with array syntax.

### DIFF
--- a/build/tasks/serve.js
+++ b/build/tasks/serve.js
@@ -14,9 +14,7 @@ gulp.task('serve', ['build'], function () {
     var serverFile =  'server/bin/www';
 
     // start the server at the beginning of the task
-    server.run({
-        file:serverFile
-    });
+    server.run([serverFile]);
 
     // rebuild the client source when files change
     gulp.watch([paths['client-source-html']], ['build-html', browserSync.reload]);
@@ -26,6 +24,6 @@ gulp.task('serve', ['build'], function () {
     // restart the server itself when backend code changes
     gulp.watch(
         ['server/*.js', 'server/routes/**/*.js'],
-        function() {server.run({ file:serverFile }); }
+        function() {server.run([serverFile]); }
         );
 });

--- a/server/bin/www
+++ b/server/bin/www
@@ -4,7 +4,8 @@
  * Module dependencies.
  */
 
-var app = require('../app');
+var path = require('path');
+var app = require(path.resolve(__dirname, '..', 'app'));
 var debug = require('debug')('server:server');
 var http = require('http');
 


### PR DESCRIPTION
Was getting this error when running `serve`. This seems to fix it for me... might I have got the wrong version of something?

```
module.js:340
throw err;










^

Error: Cannot find module '/home/jedediah/projects/pundit/app.js'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:902:3
```
